### PR TITLE
Add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: "CI"
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: "PHP ${{ matrix.php-version }}"
+
+    runs-on: 'ubuntu-latest'
+
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      matrix:
+        php-version:
+          - '7.1.28'
+          - '7.2.5'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+        experimental: [false]
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v2
+
+      - name: "Install PHP with extensions"
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          php-version: ${{ matrix.php-version }}
+          ini-values: memory_limit=-1
+
+      - name: "Add PHPUnit matcher"
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - run: composer install
+
+      - name: "Install PHPUnit"
+        run: vendor/bin/simple-phpunit install
+
+      - name: "PHPUnit version"
+        run: vendor/bin/simple-phpunit --version
+
+      - name: "Run tests"
+        run: vendor/bin/simple-phpunit
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 /composer.lock
+/.phpunit.result.cache
+/composer.phar

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr-4" : {"Utlime\\SeoMetaTags\\" : "tests/"}
     },
     "require": {
-        "php": "^7.1 || ^8.0 || ^8.1",
+        "php": "^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",
         "ext-xml": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "psr-4" : {"Utlime\\SeoMetaTags\\" : "tests/"}
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1 || ^8.0 || ^8.1",
         "ext-xml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "symfony/phpunit-bridge": "^6.2.0"
     }
 }

--- a/tests/BuilderDelegateTest.php
+++ b/tests/BuilderDelegateTest.php
@@ -13,7 +13,7 @@ class BuilderDelegateTest extends TestCase
      */
     protected $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = new BuilderDelegate(
             new CommonBuilder(),
@@ -22,7 +22,7 @@ class BuilderDelegateTest extends TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->builder = null;
     }

--- a/tests/CommonBuilderTest.php
+++ b/tests/CommonBuilderTest.php
@@ -13,12 +13,12 @@ class CommonBuilderTest extends TestCase
      */
     protected $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = new CommonBuilder();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->builder = null;
     }

--- a/tests/OpenGraphBuilderTest.php
+++ b/tests/OpenGraphBuilderTest.php
@@ -13,12 +13,12 @@ class OpenGraphBuilderTest extends TestCase
      */
     protected $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = new OpenGraphBuilder();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->builder = null;
     }

--- a/tests/TwitterBuilderTest.php
+++ b/tests/TwitterBuilderTest.php
@@ -13,12 +13,12 @@ class TwitterBuilderTest extends TestCase
      */
     protected $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = new TwitterBuilder();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->builder = null;
     }


### PR DESCRIPTION
So....I got around to updating my blog to PHP 8, and this is one of the dependencies that wouldn't install, only due to a lack of listed support in the composer.json file.

Minimum version was changed to 7.1 as due to the return types in the tests that is the minimum common version that can work across PHP versions.

